### PR TITLE
Mapping document parsing: fix metrics discovery

### DIFF
--- a/pkg/client/elasticsearch/discovery.go
+++ b/pkg/client/elasticsearch/discovery.go
@@ -175,7 +175,7 @@ type recorder struct {
 func (r *recorder) _processMappingDocument(root string, d map[string]interface{}, fieldsSet config.FieldsSet, indices []string) {
 	for k, t := range d {
 		if k == "*" {
-			return
+			continue
 		}
 		if k == "properties" {
 			tm, ok := t.(map[string]interface{})

--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -172,6 +172,7 @@ func (r *Registry) GetCustomMetricClient(info provider.CustomMetricInfo) (client
 	var metricClients *metricClients
 	var ok bool
 	if metricClients, ok = r.customMetrics[info]; !ok {
+		klog.V(1).Infof("custom metric %v is not served by any metric client", info.Metric)
 		return nil, &errors.StatusError{
 			ErrStatus: metav1.Status{
 				Status:  metav1.StatusFailure,
@@ -182,7 +183,8 @@ func (r *Registry) GetCustomMetricClient(info provider.CustomMetricInfo) (client
 	}
 	metricClient, err := metricClients.getBestMetricClient()
 	if err != nil {
-		return nil, fmt.Errorf("not backend for metric: %v", info.Metric)
+		klog.V(1).Infof("no backend for custom metric: %v", info.Metric)
+		return nil, fmt.Errorf("no backend for custom metric: %v", info.Metric)
 	}
 	klog.V(1).Infof(
 		"custom metric %v served by %s / %s", info,


### PR DESCRIPTION
When processing the mapping result we should iterate through all the children nodes even if one of them is `*`