### PR TITLE
Add support for ARM64

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,7 @@
-FROM golang:1.20.2 as builder
+FROM --platform=$TARGETPLATFORM docker.io/library/golang:1.20.4 as builder
+
+ARG TARGETPLATFORM
+ARG BUILDPLATFORM
 
 WORKDIR /go/src/github.com/elastic/elasticsearch-adapter
 
@@ -10,7 +13,7 @@ COPY main.go    main.go
 
 RUN CGO_ENABLED=0 GOOS=linux go build -o elasticsearch-adapter github.com/elastic/elasticsearch-adapter
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.7
+FROM gcr.io/distroless/static:nonroot
 
 ARG VERSION
 
@@ -23,9 +26,6 @@ LABEL name="Elasticsearch Adapter for the Kubernetes Metrics API" \
       summary="The Elasticsearch adapter for the K8S metrics APIs is an implementation of the Kubernetes resource metrics and custom metrics APIs." \
       description="The Elasticsearch adapter can be used to automatically scale applications, using the Horizontal Pod Autoscaler, querying metrics collected by Metricbeat or Agent and stored in an Elasticsearch cluster." \
       io.k8s.description="The Elasticsearch adapter can be used to automatically scale applications, using the Horizontal Pod Autoscaler, querying metrics collected by Metricbeat or Agent and stored in an Elasticsearch cluster."
-
-# Update the base image packages to the latest versions
-RUN microdnf update --setopt=tsflags=nodocs && microdnf clean all
 
 COPY --from=builder /go/src/github.com/elastic/elasticsearch-adapter/elasticsearch-adapter /
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,5 @@
 FROM --platform=$TARGETPLATFORM docker.io/library/golang:1.20.4 as builder
 
-ARG TARGETPLATFORM
-ARG BUILDPLATFORM
-
 WORKDIR /go/src/github.com/elastic/elasticsearch-adapter
 
 COPY ["go.mod", "go.sum", "./"]

--- a/Makefile
+++ b/Makefile
@@ -76,3 +76,13 @@ go-run: ## Run the adapter program locally for development purposes.
 		--secure-port=6443 \
 		--v=2 \
 		--insecure ## Allow unauthenticated calls
+
+BUILD_PLATFORM ?= "linux/amd64,linux/arm64"
+
+docker-multiarch-build: generated/openapi/zz_generated.openapi.go generate-notice-file check-license-header
+	docker buildx build . \
+		--progress=plain \
+		--build-arg VERSION='$(VERSION)' \
+		--platform $(BUILD_PLATFORM) \
+		-t $(REGISTRY)/$(NAMESPACE)/$(IMAGE):$(VERSION) \
+		--push

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -26,6 +26,7 @@ spec:
       containers:
         - name: elasticsearch-metrics-apiserver
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          workingDir: /
           securityContext:
             runAsNonRoot: true
             runAsUser: {{ .Values.runAsUser }}
@@ -68,6 +69,10 @@ spec:
             - mountPath: /var/run/serving-cert
               name: volume-serving-cert
               readOnly: false
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 12 }}
+      {{- end }}
       volumes:
         - name: config-volume
           configMap:

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -5,7 +5,7 @@ podLabels: {}
 podAnnotations: {}
 
 image:
-  repository: docker.elastic.co/elasticsearch-k8s-metrics-adapter/elasticsearch-metrics-adapter-amd64
+  repository: docker.elastic.co/elasticsearch-k8s-metrics-adapter/elasticsearch-metrics-adapter
   tag: "latest"
 
 # replicaCount is the number of operator pods to run.

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -51,3 +51,6 @@ podDisruptionBudget:
   enabled: false
   minAvailable:
   maxUnavailable: 1
+
+# tolerations defines the node tolerations.
+tolerations: []


### PR DESCRIPTION
This PR adds support for ARM64:
* Uses buildx to create and push images
* Allows toleration to be set to deploy on `kubernetes.io/arch=arm64`

This also drops UBI as the base image in favor of `gcr.io/distroless/static:nonroot`