### PR TITLE
Rename package to elasticsearch-k8s-metrics-adapter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@
 _output
 .idea/
 *.iml
-elasticsearch-adapter
+elasticsearch-k8s-metrics-adapter
 apiserver.local.config
 config/config.yml
 config/config.yaml

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM --platform=$TARGETPLATFORM docker.io/library/golang:1.20.4 as builder
 
-WORKDIR /go/src/github.com/elastic/elasticsearch-adapter
+WORKDIR /go/src/github.com/elastic/elasticsearch-k8s-metrics-adapter
 
 COPY ["go.mod", "go.sum", "./"]
 COPY generated/       generated/
@@ -8,7 +8,7 @@ COPY pkg/       pkg/
 COPY vendor/    vendor/
 COPY main.go    main.go
 
-RUN CGO_ENABLED=0 GOOS=linux go build -o elasticsearch-adapter github.com/elastic/elasticsearch-adapter
+RUN CGO_ENABLED=0 GOOS=linux go build -o elasticsearch-k8s-metrics-adapter github.com/elastic/elasticsearch-k8s-metrics-adapter
 
 FROM gcr.io/distroless/static:nonroot
 
@@ -24,9 +24,9 @@ LABEL name="Elasticsearch Adapter for the Kubernetes Metrics API" \
       description="The Elasticsearch adapter can be used to automatically scale applications, using the Horizontal Pod Autoscaler, querying metrics collected by Metricbeat or Agent and stored in an Elasticsearch cluster." \
       io.k8s.description="The Elasticsearch adapter can be used to automatically scale applications, using the Horizontal Pod Autoscaler, querying metrics collected by Metricbeat or Agent and stored in an Elasticsearch cluster."
 
-COPY --from=builder /go/src/github.com/elastic/elasticsearch-adapter/elasticsearch-adapter /
+COPY --from=builder /go/src/github.com/elastic/elasticsearch-k8s-metrics-adapter/elasticsearch-k8s-metrics-adapter /
 
 # Copy NOTICE.txt and LICENSE.txt into the image
 COPY ["NOTICE.txt", "LICENSE.txt", "/licenses/"]
 
-ENTRYPOINT ["/elasticsearch-adapter"]
+ENTRYPOINT ["/elasticsearch-k8s-metrics-adapter"]

--- a/Makefile
+++ b/Makefile
@@ -26,11 +26,11 @@ OPENAPI_PATH=./vendor/k8s.io/kube-openapi
 
 VERSION?=latest
 
-.PHONY: all docker-build build-elasticsearch-adapter test test-adapter-container go-run
+.PHONY: all docker-build build-elasticsearch-k8s-metrics-adapter test test-adapter-container go-run
 
-all: build-elasticsearch-adapter check-license-header
-build-elasticsearch-adapter: check-license-header vendor generated/openapi/zz_generated.openapi.go
-	CGO_ENABLED=0 GOOS=linux GOARCH=$(ARCH) go build -o elasticsearch-adapter github.com/elastic/elasticsearch-adapter
+all: build-elasticsearch-k8s-metrics-adapter check-license-header
+build-elasticsearch-k8s-metrics-adapter: check-license-header vendor generated/openapi/zz_generated.openapi.go
+	CGO_ENABLED=0 GOOS=linux GOARCH=$(ARCH) go build -o elasticsearch-k8s-metrics-adapter github.com/elastic/elasticsearch-k8s-metrics-adapter
 
 vendor: tidy
 	go mod vendor
@@ -43,7 +43,7 @@ test:
 
 test-kind:
 	kind load docker-image $(REGISTRY)/$(NAMESPACE)/$(IMAGE)-$(ARCH):$(VERSION)
-	kubectl apply -f deploy/elasticsearch-adapter.yaml
+	kubectl apply -f deploy/elasticsearch-k8s-metrics-adapter.yaml
 	kubectl rollout restart -n custom-metrics deployment/custom-metrics-apiserver
 
 check-license-header:

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/elastic/elasticsearch-adapter
+module github.com/elastic/elasticsearch-k8s-metrics-adapter
 
 go 1.20
 

--- a/main.go
+++ b/main.go
@@ -21,15 +21,15 @@ import (
 	"flag"
 	"os"
 
-	"github.com/elastic/elasticsearch-adapter/pkg/client"
-	"github.com/elastic/elasticsearch-adapter/pkg/client/custom_api"
-	"github.com/elastic/elasticsearch-adapter/pkg/client/elasticsearch"
-	"github.com/elastic/elasticsearch-adapter/pkg/config"
-	"github.com/elastic/elasticsearch-adapter/pkg/monitoring"
-	"github.com/elastic/elasticsearch-adapter/pkg/provider"
-	"github.com/elastic/elasticsearch-adapter/pkg/registry"
-	"github.com/elastic/elasticsearch-adapter/pkg/scheduler"
-	"github.com/elastic/elasticsearch-adapter/pkg/tracing"
+	"github.com/elastic/elasticsearch-k8s-metrics-adapter/pkg/client"
+	"github.com/elastic/elasticsearch-k8s-metrics-adapter/pkg/client/custom_api"
+	"github.com/elastic/elasticsearch-k8s-metrics-adapter/pkg/client/elasticsearch"
+	"github.com/elastic/elasticsearch-k8s-metrics-adapter/pkg/config"
+	"github.com/elastic/elasticsearch-k8s-metrics-adapter/pkg/monitoring"
+	"github.com/elastic/elasticsearch-k8s-metrics-adapter/pkg/provider"
+	"github.com/elastic/elasticsearch-k8s-metrics-adapter/pkg/registry"
+	"github.com/elastic/elasticsearch-k8s-metrics-adapter/pkg/scheduler"
+	"github.com/elastic/elasticsearch-k8s-metrics-adapter/pkg/tracing"
 	"go.elastic.co/apm"
 	"k8s.io/client-go/kubernetes"
 
@@ -40,7 +40,7 @@ import (
 	"k8s.io/component-base/logs"
 	"k8s.io/klog/v2"
 
-	generatedopenapi "github.com/elastic/elasticsearch-adapter/generated/openapi"
+	generatedopenapi "github.com/elastic/elasticsearch-k8s-metrics-adapter/generated/openapi"
 	openapinamer "k8s.io/apiserver/pkg/endpoints/openapi"
 	genericapiserver "k8s.io/apiserver/pkg/server"
 	"sigs.k8s.io/custom-metrics-apiserver/pkg/apiserver"
@@ -133,7 +133,7 @@ func main() {
 	cmd := &ElasticsearchAdapter{}
 
 	cmd.OpenAPIConfig = genericapiserver.DefaultOpenAPIConfig(generatedopenapi.GetOpenAPIDefinitions, openapinamer.NewDefinitionNamer(apiserver.Scheme))
-	cmd.OpenAPIConfig.Info.Title = "elasticsearch-adapter"
+	cmd.OpenAPIConfig.Info.Title = "elasticsearch-k8s-metrics-adapter"
 	cmd.OpenAPIConfig.Info.Version = "0.1.0"
 	logs.AddFlags(cmd.Flags())
 	cmd.Flags().BoolVar(&cmd.Insecure, "insecure", false, "if true authentication and authorization are disabled, only to be used in dev mode")

--- a/main.go
+++ b/main.go
@@ -21,6 +21,20 @@ import (
 	"flag"
 	"os"
 
+	// Load all auth plugins
+	_ "k8s.io/client-go/plugin/pkg/client/auth"
+
+	"k8s.io/apimachinery/pkg/util/wait"
+	openapinamer "k8s.io/apiserver/pkg/endpoints/openapi"
+	genericapiserver "k8s.io/apiserver/pkg/server"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/component-base/logs"
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/custom-metrics-apiserver/pkg/apiserver"
+	basecmd "sigs.k8s.io/custom-metrics-apiserver/pkg/cmd"
+	cm_provider "sigs.k8s.io/custom-metrics-apiserver/pkg/provider"
+
+	generatedopenapi "github.com/elastic/elasticsearch-k8s-metrics-adapter/generated/openapi"
 	"github.com/elastic/elasticsearch-k8s-metrics-adapter/pkg/client"
 	"github.com/elastic/elasticsearch-k8s-metrics-adapter/pkg/client/custom_api"
 	"github.com/elastic/elasticsearch-k8s-metrics-adapter/pkg/client/elasticsearch"
@@ -31,21 +45,6 @@ import (
 	"github.com/elastic/elasticsearch-k8s-metrics-adapter/pkg/scheduler"
 	"github.com/elastic/elasticsearch-k8s-metrics-adapter/pkg/tracing"
 	"go.elastic.co/apm"
-	"k8s.io/client-go/kubernetes"
-
-	// Load all auth plugins
-	_ "k8s.io/client-go/plugin/pkg/client/auth"
-
-	"k8s.io/apimachinery/pkg/util/wait"
-	"k8s.io/component-base/logs"
-	"k8s.io/klog/v2"
-
-	generatedopenapi "github.com/elastic/elasticsearch-k8s-metrics-adapter/generated/openapi"
-	openapinamer "k8s.io/apiserver/pkg/endpoints/openapi"
-	genericapiserver "k8s.io/apiserver/pkg/server"
-	"sigs.k8s.io/custom-metrics-apiserver/pkg/apiserver"
-	basecmd "sigs.k8s.io/custom-metrics-apiserver/pkg/cmd"
-	cm_provider "sigs.k8s.io/custom-metrics-apiserver/pkg/provider"
 )
 
 type ElasticsearchAdapter struct {

--- a/pkg/client/custom_api/client.go
+++ b/pkg/client/custom_api/client.go
@@ -22,8 +22,6 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/elastic/elasticsearch-adapter/pkg/client"
-	"github.com/elastic/elasticsearch-adapter/pkg/config"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -42,6 +40,9 @@ import (
 	externalMetricsAPI "k8s.io/metrics/pkg/apis/external_metrics/v1beta1"
 	cmClient "k8s.io/metrics/pkg/client/custom_metrics"
 	emClient "k8s.io/metrics/pkg/client/external_metrics"
+
+	"github.com/elastic/elasticsearch-k8s-metrics-adapter/pkg/client"
+	"github.com/elastic/elasticsearch-k8s-metrics-adapter/pkg/config"
 )
 
 type metricsClientProvider struct {

--- a/pkg/client/elasticsearch/client.go
+++ b/pkg/client/elasticsearch/client.go
@@ -27,9 +27,6 @@ import (
 	"os"
 	"sync"
 
-	"github.com/elastic/elasticsearch-adapter/pkg/client"
-	"github.com/elastic/elasticsearch-adapter/pkg/config"
-	"github.com/elastic/elasticsearch-adapter/pkg/tracing"
 	esv8 "github.com/elastic/go-elasticsearch/v8"
 	"go.elastic.co/apm"
 	"go.elastic.co/apm/module/apmelasticsearch"
@@ -44,6 +41,10 @@ import (
 	"k8s.io/metrics/pkg/apis/external_metrics"
 	"sigs.k8s.io/custom-metrics-apiserver/pkg/provider"
 	"sigs.k8s.io/custom-metrics-apiserver/pkg/provider/helpers"
+
+	"github.com/elastic/elasticsearch-k8s-metrics-adapter/pkg/client"
+	"github.com/elastic/elasticsearch-k8s-metrics-adapter/pkg/config"
+	"github.com/elastic/elasticsearch-k8s-metrics-adapter/pkg/tracing"
 )
 
 const (

--- a/pkg/client/elasticsearch/discovery.go
+++ b/pkg/client/elasticsearch/discovery.go
@@ -23,13 +23,14 @@ import (
 	"fmt"
 	"text/template"
 
-	"github.com/elastic/elasticsearch-adapter/pkg/config"
 	esv8 "github.com/elastic/go-elasticsearch/v8"
 	"github.com/elastic/go-elasticsearch/v8/esapi"
 	"github.com/itchyny/gojq"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/custom-metrics-apiserver/pkg/provider"
+
+	"github.com/elastic/elasticsearch-k8s-metrics-adapter/pkg/config"
 )
 
 var allowedTypes = map[string]struct{}{

--- a/pkg/client/elasticsearch/query.go
+++ b/pkg/client/elasticsearch/query.go
@@ -27,7 +27,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/elastic/elasticsearch-adapter/pkg/tracing"
 	esv8 "github.com/elastic/go-elasticsearch/v8"
 	"github.com/elastic/go-elasticsearch/v8/esapi"
 	log "github.com/sirupsen/logrus"
@@ -37,6 +36,8 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/custom-metrics-apiserver/pkg/provider"
+
+	"github.com/elastic/elasticsearch-k8s-metrics-adapter/pkg/tracing"
 )
 
 type QueryParams struct {

--- a/pkg/client/metrics_client.go
+++ b/pkg/client/metrics_client.go
@@ -18,12 +18,13 @@
 package client
 
 import (
-	"github.com/elastic/elasticsearch-adapter/pkg/config"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/metrics/pkg/apis/custom_metrics"
 	"k8s.io/metrics/pkg/apis/external_metrics"
 	"sigs.k8s.io/custom-metrics-apiserver/pkg/provider"
+
+	"github.com/elastic/elasticsearch-k8s-metrics-adapter/pkg/config"
 )
 
 type Interface interface {

--- a/pkg/config/metric_types_test.go
+++ b/pkg/config/metric_types_test.go
@@ -20,9 +20,10 @@ package config_test
 import (
 	"testing"
 
-	"github.com/elastic/elasticsearch-k8s-metrics-adapter/pkg/config"
 	"github.com/stretchr/testify/assert"
 	"gopkg.in/yaml.v3"
+
+	"github.com/elastic/elasticsearch-k8s-metrics-adapter/pkg/config"
 )
 
 func TestMetricTypes_UnmarshalYAML(t *testing.T) {

--- a/pkg/config/metric_types_test.go
+++ b/pkg/config/metric_types_test.go
@@ -20,7 +20,7 @@ package config_test
 import (
 	"testing"
 
-	"github.com/elastic/elasticsearch-adapter/pkg/config"
+	"github.com/elastic/elasticsearch-k8s-metrics-adapter/pkg/config"
 	"github.com/stretchr/testify/assert"
 	"gopkg.in/yaml.v3"
 )

--- a/pkg/monitoring/server.go
+++ b/pkg/monitoring/server.go
@@ -23,13 +23,14 @@ import (
 	"net/http"
 	"sync"
 
-	"github.com/elastic/elasticsearch-adapter/pkg/client"
-	"github.com/elastic/elasticsearch-adapter/pkg/config"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/custom-metrics-apiserver/pkg/provider"
+
+	"github.com/elastic/elasticsearch-k8s-metrics-adapter/pkg/client"
+	"github.com/elastic/elasticsearch-k8s-metrics-adapter/pkg/config"
 )
 
 const defaultFailureThreshold = 3

--- a/pkg/monitoring/server_test.go
+++ b/pkg/monitoring/server_test.go
@@ -22,14 +22,15 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/elastic/elasticsearch-adapter/pkg/client"
-	"github.com/elastic/elasticsearch-adapter/pkg/config"
 	"github.com/stretchr/testify/assert"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/metrics/pkg/apis/custom_metrics"
 	"k8s.io/metrics/pkg/apis/external_metrics"
 	"sigs.k8s.io/custom-metrics-apiserver/pkg/provider"
+
+	"github.com/elastic/elasticsearch-k8s-metrics-adapter/pkg/client"
+	"github.com/elastic/elasticsearch-k8s-metrics-adapter/pkg/config"
 )
 
 func TestServer_ServeHTTP(t *testing.T) {

--- a/pkg/provider/aggregation_provider.go
+++ b/pkg/provider/aggregation_provider.go
@@ -21,7 +21,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/elastic/elasticsearch-adapter/pkg/registry"
+	"github.com/elastic/elasticsearch-k8s-metrics-adapter/pkg/registry"
 	"go.elastic.co/apm"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"

--- a/pkg/registry/clients.go
+++ b/pkg/registry/clients.go
@@ -21,7 +21,7 @@ import (
 	"fmt"
 	"sort"
 
-	"github.com/elastic/elasticsearch-adapter/pkg/client"
+	"github.com/elastic/elasticsearch-k8s-metrics-adapter/pkg/client"
 )
 
 type metricClients []client.Interface

--- a/pkg/registry/fixtures.go
+++ b/pkg/registry/fixtures.go
@@ -20,14 +20,15 @@ package registry
 import (
 	"sync"
 
-	"github.com/elastic/elasticsearch-adapter/pkg/client"
-	"github.com/elastic/elasticsearch-adapter/pkg/config"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/metrics/pkg/apis/custom_metrics"
 	"k8s.io/metrics/pkg/apis/external_metrics"
 	"sigs.k8s.io/custom-metrics-apiserver/pkg/provider"
+
+	"github.com/elastic/elasticsearch-k8s-metrics-adapter/pkg/client"
+	"github.com/elastic/elasticsearch-k8s-metrics-adapter/pkg/config"
 )
 
 type fakeMetricsClient struct {

--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -22,12 +22,13 @@ import (
 	"net/http"
 	"sync"
 
-	"github.com/elastic/elasticsearch-adapter/pkg/client"
-	"github.com/elastic/elasticsearch-adapter/pkg/scheduler"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/custom-metrics-apiserver/pkg/provider"
+
+	"github.com/elastic/elasticsearch-k8s-metrics-adapter/pkg/client"
+	"github.com/elastic/elasticsearch-k8s-metrics-adapter/pkg/scheduler"
 )
 
 // Registry maintains a list of the available metrics and the associated metrics sources.

--- a/pkg/registry/registry_test.go
+++ b/pkg/registry/registry_test.go
@@ -21,11 +21,12 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/elastic/elasticsearch-adapter/pkg/client"
 	"github.com/stretchr/testify/assert"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/custom-metrics-apiserver/pkg/provider"
+
+	"github.com/elastic/elasticsearch-k8s-metrics-adapter/pkg/client"
 )
 
 func TestRegistry_UpdateMetrics(t *testing.T) {

--- a/pkg/scheduler/job.go
+++ b/pkg/scheduler/job.go
@@ -21,10 +21,11 @@ import (
 	"sync"
 	"time"
 
-	"github.com/elastic/elasticsearch-adapter/pkg/client"
-	"github.com/elastic/elasticsearch-adapter/pkg/config"
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/custom-metrics-apiserver/pkg/provider"
+
+	"github.com/elastic/elasticsearch-k8s-metrics-adapter/pkg/client"
+	"github.com/elastic/elasticsearch-k8s-metrics-adapter/pkg/config"
 )
 
 type Job interface {

--- a/pkg/scheduler/listeners.go
+++ b/pkg/scheduler/listeners.go
@@ -18,9 +18,10 @@
 package scheduler
 
 import (
-	"github.com/elastic/elasticsearch-adapter/pkg/client"
-	"github.com/elastic/elasticsearch-adapter/pkg/config"
 	"sigs.k8s.io/custom-metrics-apiserver/pkg/provider"
+
+	"github.com/elastic/elasticsearch-k8s-metrics-adapter/pkg/client"
+	"github.com/elastic/elasticsearch-k8s-metrics-adapter/pkg/config"
 )
 
 type MetricListener interface {

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -20,8 +20,9 @@ package scheduler
 import (
 	"sync"
 
-	"github.com/elastic/elasticsearch-adapter/pkg/client"
 	"k8s.io/klog/v2"
+
+	"github.com/elastic/elasticsearch-k8s-metrics-adapter/pkg/client"
 )
 
 type Scheduler struct {


### PR DESCRIPTION
It appears this repository was renamed. But the package never was, which causes discrepancies between the folder in GOPATH and the actual package name.