### PR TITLE
Helm chart: add missing cluster role binding

### DIFF
--- a/helm/templates/cluster-role-binding.yaml
+++ b/helm/templates/cluster-role-binding.yaml
@@ -36,3 +36,16 @@ subjects:
   - kind: ServiceAccount
     name: elasticsearch-metrics-apiserver
     namespace: {{ .Release.Namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: elasticsearch-metrics-apiserver-resource-reader
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: elasticsearch-metrics-apiserver-resource-reader
+subjects:
+  - kind: ServiceAccount
+    name: elasticsearch-metrics-apiserver
+    namespace: {{ .Release.Namespace }}


### PR DESCRIPTION
Binding to cluster role `elasticsearch-metrics-apiserver-resource-reader` is missing.