### PR TITLE
Create ClusterRoleBinding for resource-reader ClusterRole

### DIFF
--- a/helm/templates/cluster-role-binding.yaml
+++ b/helm/templates/cluster-role-binding.yaml
@@ -27,6 +27,19 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
+  name: elasticsearch-metrics-apiserver-resource-reader
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: elasticsearch-metrics-apiserver-resource-reader
+subjects:
+  - kind: ServiceAccount
+    name: elasticsearch-metrics-apiserver
+    namespace: {{ .Release.Namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
   name: elasticsearch-metrics-apiserver:system:auth-delegator
 roleRef:
   apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
We need this cluster role binding to be able to retrieve custom pod metrics.
Without it, HPAs get the following error:

> ScalingActive   False   FailedGetPodsMetric  the HPA was unable to compute the replica count: unable to get metric server.request.concurrent_count: unable to fetch metrics from custom metrics API: pods is forbidden: User "system:serviceaccount:elastic-agent:elasticsearch-metrics-apiserver" cannot list resource "pods" in API group "" in the namespace "elastic-system"

With this cluster role in a dev space, my HPA is able to properly retrieve its custom metric:

```
Name:                                         apm-ingest-service
Namespace:                                    elastic-system
Labels:                                       <none>
Annotations:                                  <none>
CreationTimestamp:                            Wed, 07 Jun 2023 09:45:38 +0200
Reference:                                    Deployment/apm-ingest-service
Metrics:                                      ( current / target )
  "server.request.concurrent_count" on pods:  0 / 100
Min replicas:                                 1
Max replicas:                                 3
Behavior:
  Scale Up:
    Stabilization Window: 0 seconds
    Select Policy: Max
    Policies:
      - Type: Pods     Value: 4    Period: 15 seconds
      - Type: Percent  Value: 100  Period: 15 seconds
  Scale Down:
    Stabilization Window: 5 seconds
    Select Policy: Max
    Policies:
      - Type: Percent  Value: 100  Period: 15 seconds
Deployment pods:       1 current / 1 desired
Conditions:
  Type            Status  Reason              Message
  ----            ------  ------              -------
  AbleToScale     True    ReadyForNewScale    recommended size matches current size
  ScalingActive   True    ValidMetricFound    the HPA was able to successfully calculate a replica count from pods metric server.request.concurrent_count
  ScalingLimited  False   DesiredWithinRange  the desired count is within the acceptable range
```