### PR TITLE
Add value when getFloat has an incompatible one

### DIFF
--- a/pkg/client/elasticsearch/query.go
+++ b/pkg/client/elasticsearch/query.go
@@ -21,7 +21,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"math"
 	"strings"
@@ -213,7 +212,7 @@ func getFloat(v interface{}) (float64, error) {
 	case int64:
 		return float64(i), nil
 	default:
-		return math.NaN(), errors.New("getFloat: value is of incompatible type")
+		return math.NaN(), fmt.Errorf("getFloat: value is of incompatible type: %v", v)
 	}
 }
 


### PR DESCRIPTION
I was getting this error in my HPA (most likely because of a query which didn't return any values), though because the error doesn't display the actual value (whereas the `getTimestamp` one does), I was unable to know whether it was `nil`, or anything else.