### PR TITLE
Remove global agent declaration

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,8 +1,3 @@
-agents:
-  image: "docker.elastic.co/ci-agent-images/eck-region/go-builder-buildkite-agent:1.20"
-  cpu: "4"
-  memory: "4G"
-
 env:
   DOCKER_IMAGE: "docker.elastic.co/cloud-ci/k8s-arch/elasticsearch-k8s-metrics-adapter"
   DOCKER_IMAGE_TAG: "git-${BUILDKITE_COMMIT:0:12}"
@@ -13,6 +8,10 @@ steps:
     key: "tests"
     artifact_paths:
       - "coverage.out"
+    agents:
+      image: "docker.elastic.co/ci-agent-images/eck-region/go-builder-buildkite-agent:1.20"
+      cpu: "4"
+      memory: "4G"
 
   - label: ":sonarqube: Static Code Analysis"
     env:
@@ -27,10 +26,18 @@ steps:
 
   - label: ":go: Build"
     command: "make all"
-  
+    agents:
+      image: "docker.elastic.co/ci-agent-images/eck-region/go-builder-buildkite-agent:1.20"
+      cpu: "4"
+      memory: "4G"
+
   - label: ":helm: validate helm charts"
     command: "make validate-helm"
-  
+    agents:
+      image: "docker.elastic.co/ci-agent-images/eck-region/go-builder-buildkite-agent:1.20"
+      cpu: "4"
+      memory: "4G"
+
   - label: "Package Helm Charts and push into registry"
     command: "make -C /agent helm-publish"
     env:
@@ -46,7 +53,7 @@ steps:
       - label: ":docker: :seedling: Trigger Image Creation"
         command: "make -C /agent generate-docker-images"
         agents:
-          image: "docker.elastic.co/ci-agent-images/serverless-docker-builder:0.0.4"
+          image: "docker.elastic.co/ci-agent-images/serverless-docker-builder:0.0.6"
   
   - wait
   


### PR DESCRIPTION
This removes the global agent declaration to resolve an issue with the serverless-docker-builder where the image of the global agent is used with the agent definition used to build ARM images.