### PR TITLE
Remove default cpu limit.

### DIFF
--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -43,13 +43,10 @@ spec:
             "--cert-dir=/var/run/serving-cert",
             "--v", "{{ .Values.logVerbosity }}",
           ]
+          {{- with $.Values.resources }}
           resources:
-            limits:
-              cpu: "{{ .Values.resources.limits.cpu }}"
-              memory: "{{ .Values.resources.limits.memory }}"
-            requests:
-              cpu:  "{{ .Values.resources.requests.cpu }}"
-              memory: "{{ .Values.resources.requests.memory }}"
+          {{- toYaml . | nindent 12 }}
+          {{- end }}
           ports:
             - containerPort: 6443
               name: https

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -13,7 +13,6 @@ replicaCount: 1
 
 resources:
   limits:
-    cpu: "1"
     memory: 1Gi
   requests:
     cpu: "1"


### PR DESCRIPTION
This will remove the default cpu limit, as we currently do not want to adversely effect the performance of the metrics-adapter when nearing the cpu limits.

Verification of helm changes:
```
❯ helm template es-metrics . -s templates/deployment.yaml | yq '.spec.template.spec.containers[0].resources'
limits:
  memory: 1Gi
requests:
  cpu: "1"
  memory: 1Gi

❯ helm template es-metrics . -s templates/deployment.yaml --set resources=null | yq '.spec.template.spec.containers[0]'
name: elasticsearch-metrics-apiserver
image: "docker.elastic.co/cloud-ci/k8s-arch/elasticsearch-k8s-metrics-adapter:latest"
workingDir: /
securityContext:
  runAsNonRoot: true
  runAsUser: 1111
envFrom:
  - secretRef:
      name: hpa-elasticsearch-credentials
env:
args: ["--secure-port", "6443", "--cert-dir=/var/run/serving-cert", "--v", "1"]
ports:
  - containerPort: 6443
    name: https
  - containerPort: 8080
    name: http
  - containerPort: 9090
    name: monitoring
readinessProbe:
  httpGet:
    port: monitoring
    path: /readyz
volumeMounts:
  - name: config-volume
    mountPath: /config
  - name: temp-vol
    mountPath: /tmp
  - mountPath: /var/run/serving-cert
    name: volume-serving-cert
    readOnly: false
```