### PR TITLE
Fix root level metrics

### DIFF
--- a/pkg/client/elasticsearch/discover_test.go
+++ b/pkg/client/elasticsearch/discover_test.go
@@ -1,0 +1,124 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE.txt file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package elasticsearch
+
+import (
+	"encoding/json"
+	"io"
+	"os"
+	"path"
+	"sort"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/elastic/elasticsearch-k8s-metrics-adapter/pkg/config"
+)
+
+func Test_recorder_processMappingDocument(t *testing.T) {
+	testConfig, err := config.From(
+		[]byte(`
+metricServers:
+  - name: k8s-region-observability-cluster
+    serverType: elasticsearch
+    metricSets:
+      - indices: [ '*' ]
+`),
+	)
+	if err != nil {
+		panic(err)
+	}
+	type args struct {
+		mapping interface{}
+		fields  config.FieldsSet
+		indices []string
+	}
+	tests := []struct {
+		name        string
+		args        args
+		wantMetrics []string
+	}{
+		{
+			args: args{
+				mapping: mustReadMapping(path.Join("testdata", "mapping.json")),
+				fields:  testConfig.MetricServers[0].MetricSets[0].Fields,
+				indices: testConfig.MetricServers[0].MetricSets[0].Indices,
+			},
+			wantMetrics: []string{
+				"event.duration",
+				"host.cpu.usage",
+				"metricset.period",
+				"root_metric",
+				"system.cpu.cores",
+				"system.cpu.idle.norm.pct",
+				"system.cpu.idle.pct",
+				"system.cpu.iowait.norm.pct",
+				"system.cpu.iowait.pct",
+				"system.cpu.irq.norm.pct",
+				"system.cpu.irq.pct",
+				"system.cpu.nice.norm.pct",
+				"system.cpu.nice.pct",
+				"system.cpu.softirq.norm.pct",
+				"system.cpu.softirq.pct",
+				"system.cpu.steal.norm.pct",
+				"system.cpu.steal.pct",
+				"system.cpu.system.norm.pct",
+				"system.cpu.system.pct",
+				"system.cpu.total.norm.pct",
+				"system.cpu.total.pct",
+				"system.cpu.user.norm.pct",
+				"system.cpu.user.pct",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			noopNamer, err := config.NewNamer(nil)
+			assert.NoError(t, err)
+			metricRecorder := newRecorder(noopNamer)
+			metricRecorder.processMappingDocument(tt.args.mapping, tt.args.fields, tt.args.indices)
+			sortedResult := make([]string, 0, len(metricRecorder.metrics))
+			for metric := range metricRecorder.metrics {
+				sortedResult = append(sortedResult, metric)
+			}
+			sort.Strings(sortedResult)
+			assert.Empty(t, cmp.Diff(tt.wantMetrics, sortedResult))
+		})
+	}
+}
+
+func mustReadMapping(file string) interface{} {
+	f, err := os.Open(file)
+	if err != nil {
+		panic(err)
+	}
+	d, err := io.ReadAll(f)
+	if err != nil {
+		panic(err)
+	}
+	i := map[string]interface{}{}
+	if err := json.Unmarshal(d, &i); err != nil {
+		panic(err)
+	}
+	mapping, hasMapping := i["mappings"]
+	if !hasMapping {
+		panic("mo mapping in test file")
+	}
+	return mapping
+}

--- a/pkg/client/elasticsearch/discovery.go
+++ b/pkg/client/elasticsearch/discovery.go
@@ -203,8 +203,14 @@ func (r *recorder) _processMappingDocument(root string, d map[string]interface{}
 				if t, hasType := child["type"]; !(hasType && isTypeAllowed(t.(string))) {
 					continue
 				}
+				metricName := ""
 				// New metric
-				metricName := fmt.Sprintf("%s.%s", root, k)
+				if root == "" {
+					metricName = k
+				} else {
+					metricName = fmt.Sprintf("%s.%s", root, k)
+				}
+
 				fields := fieldsSet.FindMetadata(metricName)
 				if fields == nil {
 					// field does not match a pattern, do not register it as available

--- a/pkg/client/elasticsearch/testdata/mapping.json
+++ b/pkg/client/elasticsearch/testdata/mapping.json
@@ -1,0 +1,457 @@
+{
+  "mappings": {
+    "_data_stream_timestamp": {
+      "enabled": true
+    },
+    "dynamic_templates": [
+      {
+        "long_metrics": {
+          "match_mapping_type": "long",
+          "mapping": {
+            "index": false,
+            "type": "long"
+          }
+        }
+      },
+      {
+        "double_metrics": {
+          "match_mapping_type": "double",
+          "mapping": {
+            "index": false,
+            "type": "float"
+          }
+        }
+      },
+      {
+        "match_ip": {
+          "match": "ip",
+          "match_mapping_type": "string",
+          "mapping": {
+            "type": "ip"
+          }
+        }
+      },
+      {
+        "match_message": {
+          "match": "message",
+          "match_mapping_type": "string",
+          "mapping": {
+            "type": "match_only_text"
+          }
+        }
+      },
+      {
+        "strings_as_keyword": {
+          "match_mapping_type": "string",
+          "mapping": {
+            "ignore_above": 1024,
+            "type": "keyword"
+          }
+        }
+      }
+    ],
+    "date_detection": false,
+    "properties": {
+      "@timestamp": {
+        "type": "date"
+      },
+      "root_metric": {
+        "type": "float",
+        "index": false
+      },
+      "agent": {
+        "properties": {
+          "ephemeral_id": {
+            "type": "keyword",
+            "ignore_above": 1024
+          },
+          "id": {
+            "type": "keyword",
+            "ignore_above": 1024
+          },
+          "name": {
+            "type": "keyword",
+            "ignore_above": 1024
+          },
+          "type": {
+            "type": "keyword",
+            "ignore_above": 1024
+          },
+          "version": {
+            "type": "keyword",
+            "ignore_above": 1024
+          }
+        }
+      },
+      "cloud": {
+        "properties": {
+          "account": {
+            "properties": {
+              "id": {
+                "type": "keyword",
+                "ignore_above": 1024
+              }
+            }
+          },
+          "availability_zone": {
+            "type": "keyword",
+            "ignore_above": 1024
+          },
+          "instance": {
+            "properties": {
+              "id": {
+                "type": "keyword",
+                "ignore_above": 1024
+              },
+              "name": {
+                "type": "keyword",
+                "ignore_above": 1024
+              }
+            }
+          },
+          "machine": {
+            "properties": {
+              "type": {
+                "type": "keyword",
+                "ignore_above": 1024
+              }
+            }
+          },
+          "project": {
+            "properties": {
+              "id": {
+                "type": "keyword",
+                "ignore_above": 1024
+              }
+            }
+          },
+          "provider": {
+            "type": "keyword",
+            "ignore_above": 1024
+          },
+          "service": {
+            "properties": {
+              "name": {
+                "type": "keyword",
+                "ignore_above": 1024
+              }
+            }
+          }
+        }
+      },
+      "data_stream": {
+        "properties": {
+          "dataset": {
+            "type": "constant_keyword",
+            "value": "system.cpu"
+          },
+          "namespace": {
+            "type": "constant_keyword",
+            "value": "default"
+          },
+          "type": {
+            "type": "constant_keyword",
+            "value": "metrics"
+          }
+        }
+      },
+      "ecs": {
+        "properties": {
+          "version": {
+            "type": "keyword",
+            "ignore_above": 1024
+          }
+        }
+      },
+      "elastic_agent": {
+        "properties": {
+          "id": {
+            "type": "keyword",
+            "ignore_above": 1024
+          },
+          "snapshot": {
+            "type": "boolean"
+          },
+          "version": {
+            "type": "keyword",
+            "ignore_above": 1024
+          }
+        }
+      },
+      "event": {
+        "properties": {
+          "dataset": {
+            "type": "keyword",
+            "ignore_above": 1024
+          },
+          "duration": {
+            "type": "long",
+            "index": false
+          },
+          "module": {
+            "type": "keyword",
+            "ignore_above": 1024
+          }
+        }
+      },
+      "host": {
+        "properties": {
+          "architecture": {
+            "type": "keyword",
+            "ignore_above": 1024
+          },
+          "containerized": {
+            "type": "boolean"
+          },
+          "cpu": {
+            "properties": {
+              "usage": {
+                "type": "float",
+                "index": false
+              }
+            }
+          },
+          "hostname": {
+            "type": "keyword",
+            "ignore_above": 1024
+          },
+          "ip": {
+            "type": "ip"
+          },
+          "mac": {
+            "type": "keyword",
+            "ignore_above": 1024
+          },
+          "name": {
+            "type": "keyword",
+            "ignore_above": 1024
+          },
+          "os": {
+            "properties": {
+              "codename": {
+                "type": "keyword",
+                "ignore_above": 1024
+              },
+              "family": {
+                "type": "keyword",
+                "ignore_above": 1024
+              },
+              "kernel": {
+                "type": "keyword",
+                "ignore_above": 1024
+              },
+              "name": {
+                "type": "keyword",
+                "ignore_above": 1024
+              },
+              "platform": {
+                "type": "keyword",
+                "ignore_above": 1024
+              },
+              "type": {
+                "type": "keyword",
+                "ignore_above": 1024
+              },
+              "version": {
+                "type": "keyword",
+                "ignore_above": 1024
+              }
+            }
+          }
+        }
+      },
+      "metricset": {
+        "properties": {
+          "name": {
+            "type": "keyword",
+            "ignore_above": 1024
+          },
+          "period": {
+            "type": "long",
+            "index": false
+          }
+        }
+      },
+      "orchestrator": {
+        "properties": {
+          "cluster": {
+            "properties": {
+              "name": {
+                "type": "keyword",
+                "ignore_above": 1024
+              },
+              "url": {
+                "type": "keyword",
+                "ignore_above": 1024
+              }
+            }
+          }
+        }
+      },
+      "service": {
+        "properties": {
+          "type": {
+            "type": "keyword",
+            "ignore_above": 1024
+          }
+        }
+      },
+      "system": {
+        "properties": {
+          "cpu": {
+            "properties": {
+              "cores": {
+                "type": "long",
+                "index": false
+              },
+              "idle": {
+                "properties": {
+                  "norm": {
+                    "properties": {
+                      "pct": {
+                        "type": "float",
+                        "index": false
+                      }
+                    }
+                  },
+                  "pct": {
+                    "type": "float",
+                    "index": false
+                  }
+                }
+              },
+              "iowait": {
+                "properties": {
+                  "norm": {
+                    "properties": {
+                      "pct": {
+                        "type": "long",
+                        "index": false
+                      }
+                    }
+                  },
+                  "pct": {
+                    "type": "long",
+                    "index": false
+                  }
+                }
+              },
+              "irq": {
+                "properties": {
+                  "norm": {
+                    "properties": {
+                      "pct": {
+                        "type": "long",
+                        "index": false
+                      }
+                    }
+                  },
+                  "pct": {
+                    "type": "long",
+                    "index": false
+                  }
+                }
+              },
+              "nice": {
+                "properties": {
+                  "norm": {
+                    "properties": {
+                      "pct": {
+                        "type": "long",
+                        "index": false
+                      }
+                    }
+                  },
+                  "pct": {
+                    "type": "long",
+                    "index": false
+                  }
+                }
+              },
+              "softirq": {
+                "properties": {
+                  "norm": {
+                    "properties": {
+                      "pct": {
+                        "type": "long",
+                        "index": false
+                      }
+                    }
+                  },
+                  "pct": {
+                    "type": "float",
+                    "index": false
+                  }
+                }
+              },
+              "steal": {
+                "properties": {
+                  "norm": {
+                    "properties": {
+                      "pct": {
+                        "type": "long",
+                        "index": false
+                      }
+                    }
+                  },
+                  "pct": {
+                    "type": "long",
+                    "index": false
+                  }
+                }
+              },
+              "system": {
+                "properties": {
+                  "norm": {
+                    "properties": {
+                      "pct": {
+                        "type": "float",
+                        "index": false
+                      }
+                    }
+                  },
+                  "pct": {
+                    "type": "float",
+                    "index": false
+                  }
+                }
+              },
+              "total": {
+                "properties": {
+                  "norm": {
+                    "properties": {
+                      "pct": {
+                        "type": "float",
+                        "index": false
+                      }
+                    }
+                  },
+                  "pct": {
+                    "type": "float",
+                    "index": false
+                  }
+                }
+              },
+              "user": {
+                "properties": {
+                  "norm": {
+                    "properties": {
+                      "pct": {
+                        "type": "float",
+                        "index": false
+                      }
+                    }
+                  },
+                  "pct": {
+                    "type": "float",
+                    "index": false
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
It looks like it's not possible to query root level metrics, moreover they appear in the metrics API prefixed by a dot like `pods/.metric`

That PR fix that

Before that change querying the metric server return either if querying with or without the `.`
```
Error from server (NotFound): the server could not find the metric .http_server_tcp_active for pods xxx with selector

Error from server: failed to get metrics backend: custom metric http_server_tcp_active is not served by any metric client
```


Thanks for the help on testing this @kvalliyurnatt I was able to deploy this in a dev env and able to query my root level metrics that were previously failing, non root level variable seems to still work well too
```
kubectl get --raw "/apis/custom.metrics.k8s.io/v1beta2/namespaces/xxxxxx/pods/xxx/http_server_tcp_active"
return the metric
```