### PR TITLE
Register the service as a Component in Backstage

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,3 +1,20 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: elasticsearch-k8s-metrics-adapter
+  description: An implementation of the Kubernetes Custom Metrics API for Elasticsearch
+  tags:
+    - serverless
+    - regional
+  annotations:
+    github.com/project-slug: elastic/elasticsearch-k8s-metrics-adapter
+    buildkite.com/project-slug: elastic/elasticsearch-k8s-metrics-adapter
+    sonarqube.org/project-key: elasticsearch-k8s-metrics-adapter
+spec:
+  type: service
+  lifecycle: experimental
+  owner: group:cloud-k8s-operator
+  system: control-plane
 ---
 # yaml-language-server: $schema=https://gist.githubusercontent.com/elasticmachine/988b80dae436cafea07d9a4a460a011d/raw/e57ee3bed7a6f73077a3f55a38e76e40ec87a7cf/rre.schema.json
 apiVersion: backstage.io/v1alpha1


### PR DESCRIPTION
This registers the service as a `Component` in Backstage, which is required to pass the PRR.

Relates to https://elasticco.atlassian.net/browse/PRR-3294.