### PR TITLE
Fix Labels: Add back using `podLabels`.

### DIFF
--- a/helm/templates/_helpers.tpl
+++ b/helm/templates/_helpers.tpl
@@ -18,3 +18,12 @@ Combined labels for deployment, pods, and pdb
 {{- $new := merge .Values.additionalLabels $commonLabels }}
 {{- toYaml $new }}
 {{- end -}}
+
+{{/*
+Combined Pod labels
+*/}}
+{{- define "elasticsearch-metrics-apiserver.combinedPodLabels" -}}
+{{- $combinedLabels := fromYaml (include "elasticsearch-metrics-apiserver.combinedLabels" .) -}}
+{{- $new := merge .Values.podLabels $combinedLabels }}
+{{- toYaml $new }}
+{{- end -}}

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -12,7 +12,7 @@ spec:
   template:
     metadata:
       labels:
-        {{- include "elasticsearch-metrics-apiserver.combinedLabels" . | nindent 8 }}
+        {{- include "elasticsearch-metrics-apiserver.combinedPodLabels" . | nindent 8 }}
       annotations:
         {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}


### PR DESCRIPTION
`podLabels` already existed in the helm chart, and I failed to include it in the labels included with the pods in the deployment in #55.