### PR TITLE
Add profiling server for pprof

### DIFF
--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -39,6 +39,7 @@ spec:
             "--secure-port", "6443",
             "--cert-dir=/var/run/serving-cert",
             "--v", "{{ .Values.logVerbosity }}",
+            "{{ .Values.enableProfiling }}",
           ]
           {{- with $.Values.resources }}
           resources:

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -39,7 +39,9 @@ spec:
             "--secure-port", "6443",
             "--cert-dir=/var/run/serving-cert",
             "--v", "{{ .Values.logVerbosity }}",
-            "{{ .Values.enableProfiling }}",
+            {{ if .Values.enableProfiling }}
+            "--enable-profiling",
+            {{ end }}
           ]
           {{- with $.Values.resources }}
           resources:

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -39,9 +39,9 @@ spec:
             "--secure-port", "6443",
             "--cert-dir=/var/run/serving-cert",
             "--v", "{{ .Values.logVerbosity }}",
-            {{ if .Values.enableProfiling }}
+            {{- if .Values.enableProfiling }}
             "--enable-profiling",
-            {{ end }}
+            {{- end }}
           ]
           {{- with $.Values.resources }}
           resources:

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -39,9 +39,7 @@ spec:
             "--secure-port", "6443",
             "--cert-dir=/var/run/serving-cert",
             "--v", "{{ .Values.logVerbosity }}",
-            {{- if .Values.enableProfiling }}
-            "--enable-profiling",
-            {{- end }}
+            "--profiling-port", "{{ .Values.profilingPort}}",
           ]
           {{- with $.Values.resources }}
           resources:

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -56,3 +56,5 @@ podDisruptionBudget:
 
 # tolerations defines the node tolerations.
 tolerations: []
+
+enableProfiling: "--enable-profiling"

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -57,5 +57,5 @@ podDisruptionBudget:
 # tolerations defines the node tolerations.
 tolerations: []
 
-# enable pprof profiling
-enableProfiling: false
+# port to run the pprof profiling server on, server is not start if port is 0.
+profilingPort: 8085

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -58,4 +58,4 @@ podDisruptionBudget:
 tolerations: []
 
 # port to run the pprof profiling server on, server is not start if port is 0.
-profilingPort: 8085
+profilingPort: 0

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -57,4 +57,5 @@ podDisruptionBudget:
 # tolerations defines the node tolerations.
 tolerations: []
 
-enableProfiling: "--enable-profiling"
+# enable profiling
+enableProfiling: ""

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -57,5 +57,5 @@ podDisruptionBudget:
 # tolerations defines the node tolerations.
 tolerations: []
 
-# port to run the pprof profiling server on, server is not start if port is 0.
+# port to run the pprof profiling server on, server is not started if port is 0.
 profilingPort: 0

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -56,6 +56,3 @@ podDisruptionBudget:
 
 # tolerations defines the node tolerations.
 tolerations: []
-
-# enable profiling
-enableProfiling: ""

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -56,3 +56,6 @@ podDisruptionBudget:
 
 # tolerations defines the node tolerations.
 tolerations: []
+
+# enable pprof profiling
+enableProfiling: false

--- a/main.go
+++ b/main.go
@@ -136,7 +136,6 @@ type ElasticsearchAdapter struct {
 	Insecure                 bool
 	PrometheusMetricsEnabled bool
 	MonitoringPort           int
-	EnableProfiling          bool
 	ProfilingPort            int
 }
 

--- a/main.go
+++ b/main.go
@@ -72,8 +72,7 @@ func main() {
 	logs.AddFlags(cmd.Flags())
 	cmd.Flags().BoolVar(&cmd.Insecure, "insecure", false, "if true authentication and authorization are disabled, only to be used in dev mode")
 	cmd.Flags().IntVar(&cmd.MonitoringPort, "monitoring-port", 9090, "port to expose readiness and Prometheus metrics")
-	cmd.Flags().BoolVar(&cmd.EnableProfiling, "enable-profiling", false, "If true starts a http server for pprof profiling")
-	cmd.Flags().IntVar(&cmd.ProfilingPort, "profiling-port", 8085, "port to expose pprof profiling")
+	cmd.Flags().IntVar(&cmd.ProfilingPort, "profiling-port", 0, "port to expose pprof profiling")
 	cmd.Flags().AddGoFlagSet(flag.CommandLine) // make sure we get the klog flags
 	err := cmd.Flags().Parse(os.Args)
 	if err != nil {
@@ -93,7 +92,7 @@ func main() {
 	monitoringServer := monitoring.NewServer(adapterCfg.MetricServers, cmd.MonitoringPort, adapterCfg.ReadinessProbe.FailureThreshold)
 	go monitoringServer.Start()
 
-	if cmd.EnableProfiling {
+	if cmd.ProfilingPort > 0 {
 		logger.Info("Starting profiling server...")
 		go profiling.StartProfiling(cmd.ProfilingPort)
 	}

--- a/pkg/monitoring/server.go
+++ b/pkg/monitoring/server.go
@@ -22,7 +22,6 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	_ "net/http/pprof"
 	"sync"
 
 	"github.com/go-logr/logr"

--- a/pkg/monitoring/server.go
+++ b/pkg/monitoring/server.go
@@ -22,6 +22,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	_ "net/http/pprof"
 	"sync"
 
 	"github.com/go-logr/logr"

--- a/pkg/profiling/server.go
+++ b/pkg/profiling/server.go
@@ -1,0 +1,29 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE.txt file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package profiling
+
+import (
+	"fmt"
+	"net/http"
+	_ "net/http/pprof"
+)
+
+func StartProfiling(profilingPort int) {
+	// Server used for pprof
+	_ = http.ListenAndServe(fmt.Sprintf(":%d", profilingPort), nil)
+}


### PR DESCRIPTION
This PR adds a seperate http server that can be used for profiling with pprof. This can be enabled using the helm chart.

The default port the server will run on is 8085. The profile can be collected by port-forwarding the specific port like 
```
kubectl port-forward pod/elasticsearch-metrics-apiserver-55556bb58d-9z6sj -n elastic-agent 8085
```

And then collecting data using pprof like below 
```
 karthikeyanvalliyurnatt@Karthikeyans-MacBook-Pro  ~/workspace/kvalliyurnatt/elasticsearch-k8s-metrics-adapter   add-profiling ?  go tool pprof -png http://localhost:8085/debug/pprof/heap                                                           ✔  10501  14:40:38
Fetching profile over HTTP from http://localhost:8085/debug/pprof/heap
Saved profile in /Users/karthikeyanvalliyurnatt/pprof/pprof.elasticsearch-k8s-metrics-adapter.alloc_objects.alloc_space.inuse_objects.inuse_space.004.pb.gz
Generating report in profile001.png
```