### PR TITLE
Update to golang v1.21

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -9,7 +9,7 @@ steps:
     artifact_paths:
       - "coverage.out"
     agents:
-      image: "docker.elastic.co/ci-agent-images/eck-region/go-builder-buildkite-agent:1.20"
+      image: "docker.elastic.co/ci-agent-images/eck-region/go-builder-buildkite-agent:1.21.3"
       cpu: "4"
       memory: "4G"
 
@@ -27,14 +27,14 @@ steps:
   - label: ":go: Build"
     command: "make all"
     agents:
-      image: "docker.elastic.co/ci-agent-images/eck-region/go-builder-buildkite-agent:1.20"
+      image: "docker.elastic.co/ci-agent-images/eck-region/go-builder-buildkite-agent:1.21.3"
       cpu: "4"
       memory: "4G"
 
   - label: ":helm: validate helm charts"
     command: "make validate-helm"
     agents:
-      image: "docker.elastic.co/ci-agent-images/eck-region/go-builder-buildkite-agent:1.20"
+      image: "docker.elastic.co/ci-agent-images/eck-region/go-builder-buildkite-agent:1.21.3"
       cpu: "4"
       memory: "4G"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$TARGETPLATFORM docker.io/library/golang:1.20.4 as builder
+FROM --platform=$TARGETPLATFORM docker.io/library/golang:1.21 as builder
 
 WORKDIR /go/src/github.com/elastic/elasticsearch-k8s-metrics-adapter
 


### PR DESCRIPTION
- Update golang base image to build the binary to `v1.21.3`
- Update go-builder-buildkite-agent to `v1.21.3`
- Update golangci-lint to `v1.54.2`