### PR TITLE
Add ldflags to initialize service.version properly

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,8 @@
 FROM --platform=$TARGETPLATFORM docker.io/library/golang:1.21 as builder
 
+ARG VERSION
+ARG SOURCE_COMMIT
+
 WORKDIR /go/src/github.com/elastic/elasticsearch-k8s-metrics-adapter
 
 COPY ["go.mod", "go.sum", "./"]
@@ -7,11 +10,9 @@ COPY generated/       generated/
 COPY pkg/       pkg/
 COPY main.go    main.go
 
-RUN CGO_ENABLED=0 GOOS=linux go build -o elasticsearch-k8s-metrics-adapter github.com/elastic/elasticsearch-k8s-metrics-adapter
+RUN CGO_ENABLED=0 GOOS=linux go build -ldflags "-X main.serviceVersion=$(echo $SOURCE_COMMIT | cut -c 1-12)" -o elasticsearch-k8s-metrics-adapter github.com/elastic/elasticsearch-k8s-metrics-adapter
 
 FROM gcr.io/distroless/static:nonroot
-
-ARG VERSION
 
 LABEL name="Elasticsearch Adapter for the Kubernetes Metrics API" \
       io.k8s.display-name="Elasticsearch " \

--- a/main.go
+++ b/main.go
@@ -52,15 +52,14 @@ import (
 )
 
 const (
-	serviceType    = "elasticsearch-k8s-metrics-adapter"
-	serviceVersion = "0.0.0"
-
+	serviceType                  = "elasticsearch-k8s-metrics-adapter"
 	elastisearchMetricServerType = "elasticsearch"
 	customMetricServerType       = "custom"
 )
 
 var (
-	logger logr.Logger
+	serviceVersion string
+	logger         logr.Logger
 )
 
 func main() {


### PR DESCRIPTION
Initialize service.version properly.
Update dockerfile to allow service.version.

Todo
- [x] Verification

```
{"log.level":"info","@timestamp":"2023-11-07T18:07:27.563Z","log.logger":"main","log.origin":{"function":"main.main","file.name":"elasticsearch-k8s-metrics-adapter/main.go","file.line":126},"message":"Starting elastic k8s metrics adapter...","service.type":"elasticsearch-k8s-metrics-adapter","service.version":"d33a44897b65","ecs.version":"1.6.0"}
```