### PR TITLE
Stop logging errors in the /readyz endpoint

### DIFF
--- a/pkg/monitoring/server.go
+++ b/pkg/monitoring/server.go
@@ -150,7 +150,6 @@ func (m *Server) readyHandler(writer http.ResponseWriter, request *http.Request)
 	if err != nil {
 		status = http.StatusServiceUnavailable
 	}
-
 	err = writeJSONResponse(writer, status, health)
 	if err != nil {
 		m.logger.Error(err, "Failed to write monitoring JSON response")

--- a/pkg/monitoring/server.go
+++ b/pkg/monitoring/server.go
@@ -144,15 +144,14 @@ func (m *Server) Start() {
 	_ = http.ListenAndServe(fmt.Sprintf(":%d", m.monitoringPort), nil)
 }
 
-func (m *Server) readyHandler(writer http.ResponseWriter, request *http.Request) {
+func (m *Server) readyHandler(writer http.ResponseWriter, _ *http.Request) {
 	status := http.StatusOK
 	health, err := m.isReadyAndHealthy()
 	if err != nil {
 		status = http.StatusServiceUnavailable
 	}
-	err = writeJSONResponse(writer, status, health)
-	if err != nil {
-		m.logger.Error(err, "Failed to write monitoring JSON response")
+	if err := writeJSONResponse(writer, status, health); err != nil {
+		m.logger.Error(err, "Failed to write readiness endpoint status to client")
 	}
 }
 

--- a/pkg/monitoring/server.go
+++ b/pkg/monitoring/server.go
@@ -140,49 +140,49 @@ func (m *Server) UpdateCustomMetrics(c client.Interface, cms map[provider.Custom
 
 func (m *Server) Start() {
 	http.Handle("/metrics", promhttp.Handler())
-	http.Handle("/readyz", m)
+	http.HandleFunc("/readyz", m.readyHandler)
 	_ = http.ListenAndServe(fmt.Sprintf(":%d", m.monitoringPort), nil)
 }
 
-func (m *Server) ServeHTTP(writer http.ResponseWriter, request *http.Request) {
+func (m *Server) readyHandler(writer http.ResponseWriter, request *http.Request) {
 	status := http.StatusOK
+	health, err := m.isReadyAndHealthy()
+	if err != nil {
+		status = http.StatusServiceUnavailable
+	}
+
+	err = writeJSONResponse(writer, status, health)
+	if err != nil {
+		m.logger.Error(err, "Failed to write monitoring JSON response")
+	}
+}
+
+func (m *Server) isReadyAndHealthy() (ClientsHealthResponse, error) {
 	m.lock.RLock()
 	defer m.lock.RUnlock()
-	for _, server := range m.metricServers {
 
-		l := m.logger.WithValues("server_name", server.Name)
-		errCtxMsg := "Failed to serve metrics over HTTP"
+	healthResponse := ClientsHealthResponse{ClientFailures: m.clientFailures, ClientOk: m.clientSuccesses}
+
+	for _, server := range m.metricServers {
 		if customMetricsSuccess, hasCustomMetrics := m.clientSuccesses.CustomMetrics[server.Name]; hasCustomMetrics && customMetricsSuccess == 0 {
-			status = http.StatusServiceUnavailable
-			l.Error(errors.New("client has not retrieved an initial set of custom metrics yet"), errCtxMsg)
-			break
+			return healthResponse, errors.New("client has not retrieved an initial set of custom metrics yet")
 		}
 
 		if externalMetricsSuccess, hasExternalMetrics := m.clientSuccesses.ExternalMetrics[server.Name]; hasExternalMetrics && externalMetricsSuccess == 0 {
-			status = http.StatusServiceUnavailable
-			l.Error(errors.New("client has not retrieved an initial set of external metrics yet"), errCtxMsg)
-			break
+			return healthResponse, errors.New("client has not retrieved an initial set of external metrics yet")
 		}
 
 		failures := m.clientFailures.CustomMetrics[server.Name]
 		if failures >= m.failureThreshold {
-			status = http.StatusServiceUnavailable
-			l.Error(fmt.Errorf("client got %d consecutive failures while retrieving custom metrics", failures), errCtxMsg)
-			break
+			return healthResponse, fmt.Errorf("client got %d consecutive failures while retrieving custom metrics", failures)
 		}
 
 		failures = m.clientFailures.ExternalMetrics[server.Name]
 		if failures >= m.failureThreshold {
-			status = http.StatusServiceUnavailable
-			l.Error(fmt.Errorf("client got %d consecutive failures while retrieving external metrics", failures), errCtxMsg)
-			break
+			return healthResponse, fmt.Errorf("client got %d consecutive failures while retrieving external metrics", failures)
 		}
 	}
-
-	err := writeJSONResponse(writer, status, ClientsHealthResponse{ClientFailures: m.clientFailures, ClientOk: m.clientSuccesses})
-	if err != nil {
-		m.logger.Error(err, "Failed to write monitoring JSON response")
-	}
+	return healthResponse, nil
 }
 
 type ClientsHealthResponse struct {

--- a/pkg/monitoring/server_test.go
+++ b/pkg/monitoring/server_test.go
@@ -19,7 +19,6 @@ package monitoring
 
 import (
 	"errors"
-	"net/http/httptest"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -33,7 +32,7 @@ import (
 	"github.com/elastic/elasticsearch-k8s-metrics-adapter/pkg/config"
 )
 
-func TestServer_ServeHTTP(t *testing.T) {
+func TestServer_isReadyAndHealthy(t *testing.T) {
 	server := NewServer([]config.MetricServer{
 		{
 			Name: "metric_server1",
@@ -49,47 +48,40 @@ func TestServer_ServeHTTP(t *testing.T) {
 	}, 1234, 0)
 
 	// Initial status: not ready
-	recorder := httptest.NewRecorder()
-	server.ServeHTTP(recorder, nil)
-	assert.Equal(t, 503, recorder.Code)
+	_, err := server.isReadyAndHealthy()
+	assert.Error(t, err)
 
 	// server1 provides some metrics
 	server.UpdateCustomMetrics(newFakeClient("metric_server1"), nil)
 	server.UpdateExternalMetrics(newFakeClient("metric_server1"), nil)
-	recorder = httptest.NewRecorder()
-	server.ServeHTTP(recorder, nil)
-	assert.Equal(t, 503, recorder.Code) // 503 as we are still waiting for others servers
+	_, err = server.isReadyAndHealthy()
+	assert.Error(t, err) // 503 as we are still waiting for others servers
 
 	// server2 provides some custom metrics
 	server.UpdateCustomMetrics(newFakeClient("metric_server2"), nil)
-	recorder = httptest.NewRecorder()
-	server.ServeHTTP(recorder, nil)
-	assert.Equal(t, 503, recorder.Code) // 503 as we are still waiting for server3
+	_, err = server.isReadyAndHealthy()
+	assert.Error(t, err) // 503 as we are still waiting for server3
 
 	// server3 provides some external metrics
 	server.UpdateExternalMetrics(newFakeClient("metric_server3"), nil)
-	recorder = httptest.NewRecorder()
-	server.ServeHTTP(recorder, nil)
-	assert.Equal(t, 200, recorder.Code)
+	_, err = server.isReadyAndHealthy()
+	assert.NoError(t, err)
 
 	// server2 is having some issues
 	server.OnError(newFakeClient("metric_server2"), config.CustomMetricType, errors.New("foo"))
 	server.OnError(newFakeClient("metric_server2"), config.CustomMetricType, errors.New("foo"))
-	recorder = httptest.NewRecorder()
-	server.ServeHTTP(recorder, nil)
-	assert.Equal(t, 200, recorder.Code) // still waiting for 1 error until 503
+	_, err = server.isReadyAndHealthy()
+	assert.NoError(t, err) // still waiting for 1 error until 503
 
 	// server2 is having some issues
 	server.OnError(newFakeClient("metric_server2"), config.CustomMetricType, errors.New("foo"))
-	recorder = httptest.NewRecorder()
-	server.ServeHTTP(recorder, nil)
-	assert.Equal(t, 503, recorder.Code) // error threshold reached
+	_, err = server.isReadyAndHealthy()
+	assert.Error(t, err) // error threshold reached
 
 	// server2 has recovered
 	server.UpdateCustomMetrics(newFakeClient("metric_server2"), nil)
-	recorder = httptest.NewRecorder()
-	server.ServeHTTP(recorder, nil)
-	assert.Equal(t, 200, recorder.Code)
+	_, err = server.isReadyAndHealthy()
+	assert.NoError(t, err)
 
 }
 

--- a/pkg/monitoring/server_test.go
+++ b/pkg/monitoring/server_test.go
@@ -55,12 +55,12 @@ func TestServer_isReadyAndHealthy(t *testing.T) {
 	server.UpdateCustomMetrics(newFakeClient("metric_server1"), nil)
 	server.UpdateExternalMetrics(newFakeClient("metric_server1"), nil)
 	_, err = server.isReadyAndHealthy()
-	assert.Error(t, err) // 503 as we are still waiting for others servers
+	assert.Error(t, err) // error as we are still waiting for others servers
 
 	// server2 provides some custom metrics
 	server.UpdateCustomMetrics(newFakeClient("metric_server2"), nil)
 	_, err = server.isReadyAndHealthy()
-	assert.Error(t, err) // 503 as we are still waiting for server3
+	assert.Error(t, err) // error as we are still waiting for server3
 
 	// server3 provides some external metrics
 	server.UpdateExternalMetrics(newFakeClient("metric_server3"), nil)
@@ -71,7 +71,7 @@ func TestServer_isReadyAndHealthy(t *testing.T) {
 	server.OnError(newFakeClient("metric_server2"), config.CustomMetricType, errors.New("foo"))
 	server.OnError(newFakeClient("metric_server2"), config.CustomMetricType, errors.New("foo"))
 	_, err = server.isReadyAndHealthy()
-	assert.NoError(t, err) // still waiting for 1 error until 503
+	assert.NoError(t, err) // still waiting for 1 client error until error
 
 	// server2 is having some issues
 	server.OnError(newFakeClient("metric_server2"), config.CustomMetricType, errors.New("foo"))


### PR DESCRIPTION
This mainly stops logging errors in `/readyz` endpoint with a small refactoring to make the code more explicit about its intent.