### PR TITLE
Update serverless-docker-builder to v0.0.10

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -54,7 +54,7 @@ steps:
       - label: ":docker: :seedling: Trigger Image Creation"
         command: "make -C /agent generate-docker-images"
         agents:
-          image: "docker.elastic.co/ci-agent-images/serverless-docker-builder:0.0.6"
+          image: "docker.elastic.co/ci-agent-images/serverless-docker-builder:0.0.10"
 
   - wait
 


### PR DESCRIPTION
This updates the serverless-docker-builder to `v0.0.10`, which avoids being rate limited by DockerHub.