### PR TITLE
fix(renovate): don't use branch automerge

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -76,6 +76,6 @@
     }
   ],
   "automergeStrategy": "squash",
-  "automergeType": "branch",
+  "automergeType": "pr",
   "separateMajorMinor": true
 }


### PR DESCRIPTION
As noted in [0], the use of `branch` automerge is no longer possible due
to branch protection requirements, and although Renovate can handle the
failure by upgrading to use a PR, it adds noise for Infosec.

Instead, we can make sure we default to `pr` strategy.

[0]: https://groups.google.com/a/elastic.co/g/dev/c/3kGf9b7gfwE

<sub>This PR was generated using [turbolift](https://github.com/Skyscanner/turbolift) by Platform DevFlow</sub>
