### PR TITLE
bump serverless-docker-builder version

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -54,7 +54,7 @@ steps:
       - label: ":docker: :seedling: Trigger Image Creation"
         command: "make -C /agent generate-docker-images"
         agents:
-          image: "docker.elastic.co/ci-agent-images/serverless-docker-builder:0.0.10"
+          image: "docker.elastic.co/ci-agent-images/serverless-docker-builder:0.0.11"
 
   - wait
 


### PR DESCRIPTION
The SSH key file referenced in the drivah config that the previous version of serverless-docker-builder creates is being removed from CI agents, bump to the latest version to avoid breaking image builds.
