### PR TITLE
Attempting to fix renovate config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,11 +1,13 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "local>elastic/renovate-config:control-plane-serverless",
     "config:base"
   ],
   "labels": [
     "renovate"
+  ],
+  "schedule": [
+    "after 1am on monday"
   ],
   "packageRules": [
     {


### PR DESCRIPTION
Fixes #70 

My guess is that a public repo cannot rely on a private config preset. 