### PR TITLE
Increase memory for build all step

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -30,7 +30,7 @@ steps:
     agents:
       image: "docker.elastic.co/ci-agent-images/eck-region/go-builder-buildkite-agent:1.22.3"
       cpu: "4"
-      memory: "4G"
+      memory: "8G"
 
   - label: ":helm: validate helm charts"
     command: "make validate-helm"


### PR DESCRIPTION
Builds are failing with  

```
/usr/local/go/pkg/tool/linux_amd64/compile: signal: killed
```

I have a hunch that it is lack of memory. 