### PR TITLE
Manifest to create dedicated namespace

### DIFF
--- a/helm/templates/cluster-role-binding.yaml
+++ b/helm/templates/cluster-role-binding.yaml
@@ -1,6 +1,9 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
+  annotations:
+    # ensure this resource is created before and delete after the deployment to minimise errors during namespace transition
+    argocd.argoproj.io/sync-wave: "1"
   name: hpa-controller-elasticsearch-metrics-apiserver
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -14,6 +17,9 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
+  annotations:
+    # ensure this resource is created before and delete after the deployment to minimise errors during namespace transition
+    argocd.argoproj.io/sync-wave: "1"
   name: elasticsearch-metrics-apiserver-proxy
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -27,6 +33,9 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
+  annotations:
+    # ensure this resource is created before and delete after the deployment to minimise errors during namespace transition
+    argocd.argoproj.io/sync-wave: "1"
   name: elasticsearch-metrics-apiserver:system:auth-delegator
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -40,6 +49,9 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
+  annotations:
+    # ensure this resource is created before and delete after the deployment to minimise errors during namespace transition
+    argocd.argoproj.io/sync-wave: "1"
   name: elasticsearch-metrics-apiserver-resource-reader
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/helm/templates/cluster-role.yaml
+++ b/helm/templates/cluster-role.yaml
@@ -1,6 +1,9 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
+  annotations:
+    # ensure this resource is created before and delete after the deployment to minimise errors during namespace transition
+    argocd.argoproj.io/sync-wave: "1"
   name: elasticsearch-metrics-apiserver-resources
 rules:
   - apiGroups:
@@ -11,6 +14,9 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
+  annotations:
+    # ensure this resource is created before and delete after the deployment to minimise errors during namespace transition
+    argocd.argoproj.io/sync-wave: "1"
   name: elasticsearch-metrics-apiserver-resource-reader
 rules:
   - apiGroups:

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -3,6 +3,9 @@ kind: Deployment
 metadata:
   labels:
     {{- include "elasticsearch-metrics-apiserver.combinedLabels" . | nindent 4 }}
+  annotations:
+    # ensure this resource is created after and delete before the rbac to minimise errors during namespace transition
+    argocd.argoproj.io/sync-wave: "2"
   name: elasticsearch-metrics-apiserver
 spec:
   replicas: {{ .Values.replicaCount }}

--- a/helm/templates/external-secret.yaml
+++ b/helm/templates/external-secret.yaml
@@ -1,0 +1,19 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: elasticsearch-metrics-apiserver-secrets
+  namespace: {{ .Release.Namespace }}
+spec:
+  refreshInterval: 5m
+  secretStoreRef:
+    name: mki-cluster-secret-store
+    kind: ClusterSecretStore
+  dataFrom: 
+    - extract:
+{{- if .Values.metadata }}
+       key: {{ printf "platform/%s/%s/%s/o11y/elastic-agent" (.Values.metadata.environment) (.Values.metadata.csp) (.Values.metadata.region) }}
+       decodingStrategy: None
+  target:
+    name: elasticsearch-metrics-apiserver-secrets
+    creationPolicy: Owner
+{{- end }}

--- a/helm/templates/namespace.yaml
+++ b/helm/templates/namespace.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations:
+    # prevent accidental namespace deletion if the app is deleted
+    argocd.argoproj.io/sync-options: Delete=false,Prune=false
+  labels:
+    common.k8s.elastic.co/type: system
+  name: elasticsearch-metrics-apiserver

--- a/helm/templates/namespace.yaml
+++ b/helm/templates/namespace.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.namespace.name }}
+{{- if .Values.namespace.create }}
 apiVersion: v1
 kind: Namespace
 metadata:
@@ -10,5 +10,5 @@ metadata:
   labels:
     {{- toYaml . | nindent 4 }}
   {{- end }}
-  name: {{ .Values.namespace.name }}
+  name: {{ .Release.Namespace }}
 {{- end }}

--- a/helm/templates/namespace.yaml
+++ b/helm/templates/namespace.yaml
@@ -1,9 +1,14 @@
+{{- if .Values.namespace.name }}
 apiVersion: v1
 kind: Namespace
 metadata:
+  {{- with .Values.namespace.annotations }}
   annotations:
-    # prevent accidental namespace deletion if the app is deleted
-    argocd.argoproj.io/sync-options: Delete=false,Prune=false
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.namespace.labels }}
   labels:
-    common.k8s.elastic.co/type: system
-  name: elasticsearch-metrics-apiserver
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  name: {{ .Values.namespace.name }}
+{{- end }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -62,3 +62,13 @@ tolerations: []
 
 # port to run the pprof profiling server on, server is not started if port is 0.
 profilingPort: 0
+
+# namespace defines where the service is installed.
+# Set the name to "", to disable namespace creation.
+namespace:
+  name: "elasticsearch-k8s-metrics-adapter"
+  annotations:
+    # prevent accidental namespace deletion if the app is deleted
+    argocd.argoproj.io/sync-options: Delete=false,Prune=false
+  labels:
+    common.k8s.elastic.co/type: system

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -63,10 +63,9 @@ tolerations: []
 # port to run the pprof profiling server on, server is not started if port is 0.
 profilingPort: 0
 
-# namespace defines where the service is installed.
-# Set the name to "", to disable namespace creation.
+# namespace defines whether the namespace should be created and with what labels/annotations.
 namespace:
-  name: "elasticsearch-k8s-metrics-adapter"
+  create: true
   annotations:
     # prevent accidental namespace deletion if the app is deleted
     argocd.argoproj.io/sync-options: Delete=false,Prune=false

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -65,7 +65,7 @@ profilingPort: 0
 
 # namespace defines whether the namespace should be created and with what labels/annotations.
 namespace:
-  create: true
+  create: false
   annotations:
     # prevent accidental namespace deletion if the app is deleted
     argocd.argoproj.io/sync-options: Delete=false,Prune=false


### PR DESCRIPTION
This adds:
- Helm values to define whether the namespace should be created and with what labels/annotations
- `sync-wave` annotations for ArgoCD to handle namespace transition
- an ExternalSecret to create the Secret with credentials to the o11y cluster and stop using the `elastic-agent` Secret

Relates to https://elasticco.atlassian.net/browse/CP-8087.