### PR TITLE
Add sync wave annotation on the API services

### DIFF
--- a/helm/templates/api-service.yaml
+++ b/helm/templates/api-service.yaml
@@ -1,6 +1,9 @@
 apiVersion: apiregistration.k8s.io/v1
 kind: APIService
 metadata:
+  annotations:
+    # ensure this resource is created after and deleted before the deployment to minimise errors during namespace transition
+    argocd.argoproj.io/sync-wave: "3"
   name: v1beta1.custom.metrics.k8s.io
 spec:
   service:
@@ -15,6 +18,9 @@ spec:
 apiVersion: apiregistration.k8s.io/v1
 kind: APIService
 metadata:
+  annotations:
+    # ensure this resource is created after and deleted before the deployment to minimise errors during namespace transition
+    argocd.argoproj.io/sync-wave: "3"
   name: v1beta2.custom.metrics.k8s.io
 spec:
   service:


### PR DESCRIPTION
This adds a sync wave annotation on the API services to create them after the deployment.

The [build](https://buildkite.com/elastic/k8s-gitops-create-devenv/builds/77219#0191b319-5d14-4d31-815a-d532b30553fd) corresponding to the merge of #118 to main fails:
```
waiting for healthy state of apiregistration.k8s.io/APIService/v1beta1.custom.metrics.k8s.io and 1 more resources
```

My understanding is that the sync is stuck because API services are not healthy because endpoints have no addresses, because there is no yet pods.
```
> k -n elastic-agent describe apiservice v1beta2.custom.metrics.k8s.io | grep -A10 Status
Status:
  Conditions:
    Last Transition Time:  2024-09-03T09:01:22Z
    Message:               endpoints for service/elasticsearch-metrics-apiserver in "elastic-agent" have no addresses with port name "https"
    Reason:                MissingEndpoints
    Status:                False
    Type:                  Available
Events:                    <none>
```

Verified in my`dev` env.
