### PR TITLE
Label the service with the combined labels

### DIFF
--- a/helm/templates/service.yaml
+++ b/helm/templates/service.yaml
@@ -2,6 +2,8 @@ apiVersion: v1
 kind: Service
 metadata:
   name: elasticsearch-metrics-apiserver
+  labels:
+    {{- include "elasticsearch-metrics-apiserver.combinedLabels" . | nindent 4 }}
 spec:
   ports:
     - name: https


### PR DESCRIPTION
This updates the Helm chart to label the Service with the combined labels. This is useful for the ongoing effort of having required labels on Deployments, Pods and Services.