### PR TITLE
chore(progressive-deployment): enable for elasticsearch-k8s-metrics-adapter

### DIFF
--- a/.buildkite/pipeline.elasticsearch-k8s-metrics-adapter-tests.yaml
+++ b/.buildkite/pipeline.elasticsearch-k8s-metrics-adapter-tests.yaml
@@ -12,6 +12,7 @@
 
 env:
   ENVIRONMENT: ${ENVIRONMENT?}
+  DEPLOYMENT_SLICES: ${DEPLOYMENT_SLICES:-""}
   TEAM_CHANNEL: "#cp-serverless-applications"
 
 steps:

--- a/.buildkite/pipeline.tests-production.yaml
+++ b/.buildkite/pipeline.tests-production.yaml
@@ -18,3 +18,4 @@ steps:
         CONTAINER_NAME: elasticsearch-metrics-apiserver
         CHECK_CONTAINER_RESTART_COUNT: true
         CHECK_METRICS_COUNT: true
+        DEPLOYMENT_SLICES: ${DEPLOYMENT_SLICES:-""}

--- a/.buildkite/pipeline.tests-qa.yaml
+++ b/.buildkite/pipeline.tests-qa.yaml
@@ -18,3 +18,4 @@ steps:
         CONTAINER_NAME: elasticsearch-metrics-apiserver
         CHECK_CONTAINER_RESTART_COUNT: true
         CHECK_METRICS_COUNT: true
+        DEPLOYMENT_SLICES: ${DEPLOYMENT_SLICES:-""}

--- a/.buildkite/pipeline.tests-staging.yaml
+++ b/.buildkite/pipeline.tests-staging.yaml
@@ -18,3 +18,4 @@ steps:
         CONTAINER_NAME: elasticsearch-metrics-apiserver
         CHECK_CONTAINER_RESTART_COUNT: true
         CHECK_METRICS_COUNT: true
+        DEPLOYMENT_SLICES: ${DEPLOYMENT_SLICES:-""}

--- a/helm/templates/_helpers.tpl
+++ b/helm/templates/_helpers.tpl
@@ -27,3 +27,9 @@ Combined Pod labels
 {{- $new := merge .Values.podLabels $combinedLabels }}
 {{- toYaml $new }}
 {{- end -}}
+
+{{- define "engprod.deploymentslice" -}}
+{{- if .Values.metadata.deploymentslice }}
+engprod.k8s.elastic.co/deploymentslice: {{ .Values.metadata.deploymentslice }}
+{{- end }}
+{{- end }}

--- a/helm/templates/_helpers.tpl
+++ b/helm/templates/_helpers.tpl
@@ -28,7 +28,7 @@ Combined Pod labels
 {{- toYaml $new }}
 {{- end -}}
 
-{{- define "engprod.deploymentslice" -}}
+{{- define "elasticsearch-metrics-apiserver.deploymentslice" -}}
 {{- if .Values.metadata.deploymentslice }}
 engprod.k8s.elastic.co/deploymentslice: {{ .Values.metadata.deploymentslice }}
 {{- end }}

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -16,7 +16,7 @@ spec:
     metadata:
       labels:
         {{- include "elasticsearch-metrics-apiserver.combinedPodLabels" . | nindent 8 }}
-        {{- with (include "engprod.deploymentslice" . | trim) }}
+        {{- with (include "elasticsearch-metrics-apiserver.deploymentslice" . | trim) }}
         {{- . | nindent 8 }}
         {{- end }}
       annotations:

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -45,13 +45,6 @@ spec:
             {{- with .Values.env }}
               {{- toYaml . | nindent 12 }}
             {{- end }}
-            - name: ELASTIC_APM_GLOBAL_LABELS
-              value: "\
-                orchestrator.target={{ (.Values.metadata).target | default "*"}},\
-                orchestrator.cluster.name={{ (.Values.metadata).cluster | default "default" }},\
-                orchestrator.environment={{ (.Values.metadata).environment | default "default" }},\
-                orchestrator.deploymentslice={{ .Values.metadata.deploymentslice | default "''" }}\
-                " 
           args: [
             "--secure-port", "6443",
             "--cert-dir=/var/run/serving-cert",

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -16,6 +16,9 @@ spec:
     metadata:
       labels:
         {{- include "elasticsearch-metrics-apiserver.combinedPodLabels" . | nindent 8 }}
+        {{- with (include "engprod.deploymentslice" . | trim) }}
+        {{- . | nindent 8 }}
+        {{- end }}
       annotations:
         {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
@@ -42,6 +45,13 @@ spec:
             {{- with .Values.env }}
               {{- toYaml . | nindent 12 }}
             {{- end }}
+            - name: ELASTIC_APM_GLOBAL_LABELS
+              value: "\
+                orchestrator.target={{ (.Values.metadata).target | default "*"}},\
+                orchestrator.cluster.name={{ (.Values.metadata).cluster | default "default" }},\
+                orchestrator.environment={{ (.Values.metadata).environment | default "default" }},\
+                orchestrator.deploymentslice={{ .Values.metadata.deploymentslice | default "''" }}\
+                " 
           args: [
             "--secure-port", "6443",
             "--cert-dir=/var/run/serving-cert",

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -1,5 +1,6 @@
 metadata:
   cluster:
+  deploymentslice: ""
 
 # Labels added to the pod
 podLabels: {}


### PR DESCRIPTION
  - Enable the helm chart bits for progressive deployments
  - Pass down deployment slice to QG