### PR TITLE
Make o11y user configurable

### DIFF
--- a/helm/templates/external-secret.yaml
+++ b/helm/templates/external-secret.yaml
@@ -11,7 +11,7 @@ spec:
   dataFrom: 
     - extract:
 {{- if .Values.metadata }}
-       key: {{ printf "platform/%s/%s/%s/o11y/elastic-agent" (.Values.metadata.environment) (.Values.metadata.csp) (.Values.metadata.region) }}
+       key: {{ printf "platform/%s/%s/%s/o11y/%s" (.Values.metadata.environment) (.Values.metadata.csp) (.Values.metadata.region) (.Values.o11yUser) }}
        decodingStrategy: None
   target:
     name: elasticsearch-metrics-apiserver-secrets

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -72,3 +72,6 @@ namespace:
     argocd.argoproj.io/sync-options: Delete=false,Prune=false
   labels:
     common.k8s.elastic.co/type: system
+
+# o11y-user is the elasticsearch user to use to query the o11y cluster
+o11yUser: elastic-agent


### PR DESCRIPTION
This makes configurable the o11y user used in the vault path of the external secret that creates the elasticsearch-metrics-apiserver-secrets Secret.

Relates to https://elasticco.atlassian.net/browse/CP-8371.