### PR TITLE
CP-7781 - switching bk pipeline to gpctl promote after synthetics

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -59,9 +59,9 @@ steps:
 
   - wait
 
-  - label: ':argo: Run e2e tests and update version on serverless-gitops'
+  - label: ":serverless::argo: Run synthetics tests and update elasticsearch-k8s-metrics-adapter to ${VERSION} in serverless-gitops"
     branches: main
-    trigger: gpctl-promote-with-e2e-tests
+    trigger: gpctl-promote-after-serverless-devenv-synthetics
     build:
       env:
         SERVICE: elasticsearch-k8s-metrics-adapter


### PR DESCRIPTION
Replacing pipeline `gpctl-promote-with-e2e-tests` with `gpctl-promote-after-serverless-devenv-synthetics`.
This will replace the execution of the E2E tests on promotion to dev/qa with the execution of the synthetics tests.
For further details please take a look at the PSA: Serverless E2E tests to synthetics.