### PR TITLE
Enable renovate digest updates for wolfi images

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -69,7 +69,8 @@
     },
     {
       "excludePackagePrefixes": [
-        "github.com/elastic/"
+        "github.com/elastic/",
+        "docker.elastic.co/wolfi/"
       ],
       "matchUpdateTypes": [
         "digest"


### PR DESCRIPTION
Enables digest based renovate updates on the chainguard base images.