### PR TITLE
group renovate updates and enable automerge for wolfi image updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -23,7 +23,8 @@
         "gomodTidy"
       ],
       "matchPackageNames": [
-        "github.com/elastic/{/,}**"
+        "github.com/elastic/{/,}**",
+        "docker.elastic.co/wolfi/{/,}**"
       ]
     },
     {

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -76,6 +76,30 @@
         "!github.com/elastic/{/,}**",
         "!docker.elastic.co/wolfi/{/,}**"
       ]
+    },
+    {
+      "groupName": "all ungrouped dependencies",
+      "matchPackageNames": [
+        "*"
+      ]
+    },
+    {
+      "groupName": "elastic-deps",
+      "matchPackageNames": [
+        "/^github.com/elastic/",
+        "/^go.elastic.co/"
+      ]
+    },
+    {
+      "matchPackageNames": [
+        "docker.elastic.co/ci-agent-images/eck-region/go-builder-buildkite-agent",
+        "go",
+        "golang",
+        "docker.io/library/golang",
+        "docker.elastic.co/wolfi/go",
+        "github.com/golangci/golangci-lint"
+      ],
+      "groupName": "go"
     }
   ],
   "automergeStrategy": "squash",


### PR DESCRIPTION
Group the dependencies in the renovate config so that we have lesser renovate PRs 
We will have three groups
1. Go dependencies
2. Elastic internal dependencies
3. Everything else

Additionally enable automerge for wolfi image updates