### PR TITLE
Approve renovate PRs via a github workflow

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -4,10 +4,8 @@
     "config:recommended"
   ],
   "labels": [
-    "renovate"
-  ],
-  "schedule": [
-    "after 1am on monday"
+    "renovate",
+    "renovate-auto-approve"
   ],
   "packageRules": [
     {
@@ -105,5 +103,9 @@
   ],
   "automergeStrategy": "squash",
   "automergeType": "pr",
+  "automergeSchedule": ["at any time"],
+  "schedule": [
+    "after 1am on monday"
+  ],
   "separateMajorMinor": true
 }

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,0 +1,25 @@
+# Workflows
+
+## auto-approve-renovate-prs
+
+This workflow automatically approves Renovate PRs created by the Renovate bot, but only if:
+
+- The PR is created by `elastic-renovate-prod[bot]` or `elastic-renovate-dev[bot]`
+- The PR has the `renovate-auto-approve` label (which is added via the `labels` configuration in our Renovate configuration)
+- The workflow is triggered by the `auto_merge_enabled` event on the `main` branch
+
+### Approval Window
+
+Approval is restricted to: Monday -> Thursday
+
+This workflow is designed to work alongside Renovate's "platform native" PR-based automerge functionality, which uses GitHub's native automerge functionality to merge the PR once CI checks pass. This two-step process enables a safer and more controlled dependency updates, without requiring Renovate bypass branch protection requirements.
+
+### Why use `auto_merge_enabled` as the event trigger?
+
+The workflow uses the `auto_merge_enabled` event instead of the standard `opened` or `synchronize` pull request events to ensure that PR approval only occurs when auto-merge has been explicitly enabled for a pull request. This provides an extra layer of control and safety by:
+
+- Preventing automatic approval of all Renovate PRs as soon as they are opened.
+- Ensuring that only PRs which had auto-merge enabled (either manually or by Renovate configuration) are auto-approved.
+- Supporting a two-step automerge process, where PRs are first created by Renovate and only then approved by GitHub Actions Bot for merging during the defined approval window.
+
+This approach helps teams maintain oversight of dependency updates while still benefiting from automation.

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -4,7 +4,7 @@
 
 This workflow automatically approves Renovate PRs created by the Renovate bot, but only if:
 
-- The PR is created by `elastic-renovate-prod[bot]` or `elastic-renovate-dev[bot]`
+- The PR is created by `elastic-renovate-prod[bot]`
 - The PR has the `renovate-auto-approve` label (which is added via the `labels` configuration in our Renovate configuration)
 - The workflow is triggered by the `auto_merge_enabled` event on the `main` branch
 

--- a/.github/workflows/auto-approve-renovate-prs.yaml
+++ b/.github/workflows/auto-approve-renovate-prs.yaml
@@ -1,0 +1,44 @@
+# This workflow automatically approves Renovate PRs created by the Renovate bot during weekdays (Monday to Thursday) between 10 PM and 4 AM UTC, or anytime on weekends (Saturday and Sunday). It checks if the PR is created by the Renovate bot and has the 'renovate-auto-approve' label before approving it.
+# Its functionality is complimentary to the renovate functionality in order to enable a 2-step PR based automerge.
+name: GitHub Actions Bot Auto-Approve Renovate PRs
+
+on:
+  pull_request:
+    branches:
+      - main
+    # auto_merge_enabled is a custom event that is triggered when a PR is created.
+    # Auto-merge will be enabled by Renovate -if configured- and this will trigger the github workflow.
+    types: [auto_merge_enabled]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  approve:
+    runs-on: ubuntu-latest
+    # The condition checks if the PR is created by the Renovate bot and has the 'renovate-auto-approve' label
+    if: (github.event.pull_request.user.login == 'elastic-renovate-prod[bot]') && contains(github.event.pull_request.labels.*.name, 'renovate-auto-approve')
+    steps:
+    # The first step of the job is to check if the current time is within the approval window
+    # As defined by the team the approval of Renovate PRs should only happen from Monday to Thursday.
+    - name: Check if workflow is triggered within approval time window
+      id: timecheck
+      shell: bash
+      run: |
+        day=$(date -u +%u) # 1=Monday, 4=Thursday
+        if [[ "$day" -ge 1 && "$day" -le 4 ]]; then
+          echo "within_window=true" >> $GITHUB_OUTPUT
+        else
+          echo "within_window=false" >> $GITHUB_OUTPUT
+        fi
+    - name: Approve Renovate PR using GitHub Actions Bot
+      if: steps.timecheck.outputs.within_window == 'true'
+      uses: actions/github-script@v8
+      with:
+        script: |
+          const result = await github.rest.pulls.createReview({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            pull_number: context.issue.number,
+            event: "APPROVE"
+          })


### PR DESCRIPTION
A copy of https://github.com/elastic/elasticsearch-controller/pull/1108.

Branch-based automerge for Renovate is deprecated, and elasticsearch-controller, for example, has already moved to using github actions to auto-approve renovate PRs.

Re: Slack disucssion => [elastic.slack.com/archives/C04KKUA8EUB/p1756470288237169](https://elastic.slack.com/archives/C04KKUA8EUB/p1756470288237169)

Rel: [elasticco.atlassian.net/browse/CPSERV-873](https://elasticco.atlassian.net/browse/CPSERV-873)