### PR TITLE
Remove SonarCube from the build pipeline

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -15,17 +15,6 @@ steps:
       cpu: "4"
       memory: "5G"
 
-  - label: ":sonarqube: Static Code Analysis"
-    env:
-      VAULT_SONAR_TOKEN_PATH: "kv/ci-shared/serverless/shared-analysis-token"
-    agents:
-      image: "docker.elastic.co/cloud-ci/sonarqube/buildkite-scanner:latest"
-    command:
-      - "buildkite-agent artifact download coverage.out ."
-      - "/scan-source-code.sh"
-    soft_fail: true
-    depends_on: "tests"
-
   - label: ":go: Build"
     command: "make all"
     agents:

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -10,7 +10,6 @@ metadata:
     backstage.io/source-location: "url:https://github.com/elastic/elasticsearch-k8s-metrics-adapter/"
     github.com/project-slug: elastic/elasticsearch-k8s-metrics-adapter
     buildkite.com/project-slug: elastic/elasticsearch-k8s-metrics-adapter
-    sonarqube.org/project-key: elasticsearch-k8s-metrics-adapter
     pagerduty.com/service-id: PA1IPRT
   tags:
     - serverless

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,7 +1,0 @@
-# must be unique in a given SonarQube instance
-sonar.projectKey=elasticsearch-k8s-metrics-adapter
-sonar.projectName=elasticsearch-k8s-metrics-adapter 
-sonar.host.url=https://sonar.elastic.dev
-sonar.go.coverage.reportPaths=coverage.out
-sonar.test.inclusions=**/*_test.go
-sonar.exclusions=**/*_test.go,**/vendor/**,**/testdata/*,**/mocks/*,internal/config/*,golangci-lint.xml,generated/**/*


### PR DESCRIPTION
This PR removes Sonarcube from the build pipeline, as well as any additional references to Sonarcube.

See also: [groups.google.com/a/elastic.co/g/dev/c/m6DbmHI6wy0](https://groups.google.com/a/elastic.co/g/dev/c/m6DbmHI6wy0)

Rel: [elasticco.atlassian.net/browse/CPSERV-875](https://elasticco.atlassian.net/browse/CPSERV-875)

(Reopened https://github.com/elastic/elasticsearch-k8s-metrics-adapter/pull/201 against main instead of against a fork)