### PR TITLE
Update ownership and notification channels to ecp-services

### DIFF
--- a/.buildkite/pipeline.elasticsearch-k8s-metrics-adapter-tests.yaml
+++ b/.buildkite/pipeline.elasticsearch-k8s-metrics-adapter-tests.yaml
@@ -13,7 +13,7 @@
 env:
   ENVIRONMENT: ${ENVIRONMENT?}
   DEPLOYMENT_SLICES: ${DEPLOYMENT_SLICES:-""}
-  TEAM_CHANNEL: "#cp-serverless-applications-notifications"
+  TEAM_CHANNEL: "#ecp-services-notifications"
 
 steps:
   - label: ":pipeline::grey_question::seedling: Trigger service tests for ${ENVIRONMENT}"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -60,5 +60,5 @@ steps:
         SERVICE_COMMIT_HASH: "${VERSION}"
 
 notify:
-  - slack: "#cp-serverless-applications-notifications"
+  - slack: "#ecp-services-notifications"
     if: build.branch == "main" && build.state == "failed" && build.source != "trigger_job"

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
-* @elastic/serverless-applications
+* @elastic/ecp-services
 

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -12,6 +12,7 @@ metadata:
     buildkite.com/project-slug: elastic/elasticsearch-k8s-metrics-adapter
     pagerduty.com/service-id: PA1IPRT
   tags:
+    - ecp
     - serverless
     - regional
     - application
@@ -36,7 +37,7 @@ metadata:
       icon: dashboard
 spec:
   type: service
-  owner: group:serverless-applications
+  owner: group:ecp-services
   lifecycle: experimental
   system: control-plane
 # Buildkite pipeline
@@ -52,7 +53,7 @@ metadata:
       url: https://buildkite.com/elastic/elasticsearch-k8s-metrics-adapter
 spec:
   type: buildkite-pipeline
-  owner: group:serverless-applications
+  owner: group:ecp-services
   system: buildkite
   implementation:
     apiVersion: buildkite.elastic.dev/v1
@@ -70,8 +71,12 @@ spec:
         publish_commit_status_per_step: false
         skip_pull_request_builds_for_existing_commits: false
       teams:
-        serverless-applications:
+        ecp-services:
           access_level: MANAGE_BUILD_AND_READ
+        everyone:
+          access_level: READ_ONLY
+        serverless-applications:
+          access_level: BUILD_AND_READ
         cloud-tooling:
           access_level: MANAGE_BUILD_AND_READ
         everyone:
@@ -90,7 +95,7 @@ metadata:
       url: https://buildkite.com/elastic/elasticsearch-k8s-metrics-adapter-tests
 spec:
   type: buildkite-pipeline
-  owner: group:serverless-applications
+  owner: group:ecp-services
   system: buildkite
   implementation:
     apiVersion: buildkite.elastic.dev/v1

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -79,8 +79,6 @@ spec:
           access_level: BUILD_AND_READ
         cloud-tooling:
           access_level: MANAGE_BUILD_AND_READ
-        everyone:
-          access_level: READ_ONLY
         serverless-core:
           access_level: BUILD_AND_READ
 # Quality gates pipeline


### PR DESCRIPTION
This PR transfers ownership of the `elasticsearch-k8s-metrics-adapter` service from the @elastic/serverless-applications team to the @elastic/ecp-services team.